### PR TITLE
Add Latexify recipe

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "5.0.3"
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 

--- a/src/ParameterizedFunctions.jl
+++ b/src/ParameterizedFunctions.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module ParameterizedFunctions
 
-  using DataStructures, DiffEqBase, ModelingToolkit
+  using DataStructures, DiffEqBase, ModelingToolkit, Latexify
 
   import LinearAlgebra
 
@@ -13,6 +13,7 @@ module ParameterizedFunctions
   include("utils.jl")
   include("dict_build.jl")
   include("macros.jl")
+  include("latexify.jl")
 
   export @ode_def,ode_def_opts,@ode_def_bare, @ode_def_all
 end # module

--- a/src/latexify.jl
+++ b/src/latexify.jl
@@ -1,0 +1,3 @@
+@latexrecipe function f(func::DiffEqBase.AbstractParameterizedFunction)
+    return latexify(func.sys)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using ParameterizedFunctions, DiffEqBase
-using Test, InteractiveUtils
+using Test, InteractiveUtils, Latexify
 
 using SpecialFunctions
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using ParameterizedFunctions, DiffEqBase
-using Test, InteractiveUtils, Latexify
+using Test, InteractiveUtils
 
 using SpecialFunctions
 
@@ -14,7 +14,7 @@ end a b c d
 @test latexify(f_t) ==
 raw"$\begin{align}
 \frac{dx(t)}{dt} =& \mathrm{x}\left( t \right) 1 \\
-\frac{dy(t)}{dt} =& \mathrm{y}\left( t \right)  - c + d \mathrm{x}\left( t \right) \mathrm{y}\left( t \right) t^{2}
+\frac{dy(t)}{dt} =& \mathrm{y}\left( t \right) \left(  - c \right) + d \mathrm{x}\left( t \right) \mathrm{y}\left( t \right) t^{2}
 \end{align}
 $"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using ParameterizedFunctions, DiffEqBase
-using Test, InteractiveUtils
+using Test, InteractiveUtils, Latexify
 
 using SpecialFunctions
 
@@ -10,6 +10,13 @@ f_t = @ode_def SymCheck begin # Checks for error due to symbol on 1
   dx = x
   dy = -c*y + d*x*y*t^2
 end a b c d
+
+@test latexify(f_t) ==
+raw"$\begin{align}
+\frac{dx(t)}{dt} =& \mathrm{x}\left( t \right) 1 \\
+\frac{dy(t)}{dt} =& \mathrm{y}\left( t \right)  - c + d \mathrm{x}\left( t \right) \mathrm{y}\left( t \right) t^{2}
+\end{align}
+$"
 
 @test DiffEqBase.__has_syms(f_t)
 


### PR DESCRIPTION
@korsbo since it's now build on ModelingToolkit, forwarding to the MTK recipe is all that's needed. Are tie-ins directly in Latexify, like https://github.com/korsbo/Latexify.jl/blob/master/src/plugins/ParameterizedFunctions.jl still needed after this?