### PR TITLE
feat: add `SciMLBase.remake` method for generated functions

### DIFF
--- a/src/ode_def_opts.jl
+++ b/src/ode_def_opts.jl
@@ -186,6 +186,10 @@ function ode_def_opts(name::Symbol, opts::Dict{Symbol, Bool}, curmod, ex::Expr, 
 
         (f::$name)(args...) = f.f(args...)
 
+        function ParameterizedFunctions.SciMLBase.remake(func::$name; kwargs...)
+            return func
+        end
+
         $fname($(f_ex_oop.args[1].args...)) = $(f_ex_oop.args[2])
         $fname($(f_ex_iip.args[1].args...)) = $(f_ex_iip.args[2])
         $full_tex

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,3 +110,13 @@ sir_ode = @ode_def SIRModel begin
     dI = b * S * I - g * I
     dR = g * I
 end b g
+
+@testset "remake" begin
+    f = @ode_def begin
+        dx = a * x - b * x * y
+        dy = -c * y + d * x * y
+    end a b c d
+    # pass dummy values, `remake` should ignore everything
+    f2 = remake(f; f = nothing, initialization_data = 3)
+    @test f2 === f
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
